### PR TITLE
Expand header and add reservation button

### DIFF
--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -8,4 +8,9 @@ describe('Navbar', () => {
     const html = renderToString(<Navbar />);
     expect(html).toContain('Chandlers');
   });
+
+  it('renders reservation button', () => {
+    const html = renderToString(<Navbar />);
+    expect(html).toContain('Book a reservation');
+  });
 });

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,8 +8,16 @@ export default function Navbar() {
 
   return (
     <nav className="bg-black/70 text-white">
-      <div className="mx-auto max-w-7xl px-4 py-3 flex justify-between items-center">
-        <Link href="/" className="site-title">Chandlers</Link>
+      <div className="mx-auto max-w-7xl px-4 py-6 flex justify-between items-center">
+        <div className="flex flex-col">
+          <Link href="/" className="site-title text-4xl">Chandlers</Link>
+          <button
+            className="mt-2 bg-black text-white px-4 py-2 rounded"
+            style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
+          >
+            Book a reservation
+          </button>
+        </div>
         <div className="relative">
           <button
             onClick={() => setOpen(!open)}


### PR DESCRIPTION
## Summary
- enlarge page header and add prominently styled reservation button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e84fb2c8331a2216dbab4eeb2a0