### PR TITLE
Expand header and add reservation button

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import HomePage from './page';
+import { describe, it, expect } from 'vitest';
+
+describe('HomePage', () => {
+  it('renders welcome header and reservation button', () => {
+    const html = renderToString(<HomePage />);
+    expect(html).toContain('Welcome to Chandlers');
+    expect(html).toContain('Book a reservation');
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,16 @@
+import React from 'react';
+
 export default function HomePage() {
   return (
     <section className="flex items-center justify-center py-24">
-      <div className="bg-black/70 p-4 rounded">
-        <h1 className="text-3xl font-bold text-white">Welcome to Chandlers</h1>
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+        <h1 className="text-6xl font-bold text-white">Welcome to Chandlers</h1>
+        <button
+          className="mt-4 bg-black text-white px-4 py-2 rounded"
+          style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
+        >
+          Book a reservation
+        </button>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- restore navbar layout without reservation button
- enlarge home page welcome header and add matching reservation button below it
- cover new reservation button with a home page test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e84fb2c8331a2216dbab4eeb2a0