### PR TITLE
Remove navbar reservation button

### DIFF
--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -9,8 +9,4 @@ describe('Navbar', () => {
     expect(html).toContain('Chandlers');
   });
 
-  it('renders reservation button', () => {
-    const html = renderToString(<Navbar />);
-    expect(html).toContain('Book a reservation');
-  });
 });

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,12 +11,6 @@ export default function Navbar() {
       <div className="mx-auto max-w-7xl px-4 py-6 flex justify-between items-center">
         <div className="flex flex-col">
           <Link href="/" className="site-title text-4xl">Chandlers</Link>
-          <button
-            className="mt-2 bg-black text-white px-4 py-2 rounded"
-            style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
-          >
-            Book a reservation
-          </button>
         </div>
         <div className="relative">
           <button


### PR DESCRIPTION
## Summary
- remove reservation button from navigation bar
- update tests to reflect button removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab942c43d88331850ae490d47deeba