### PR TITLE
Add reservations page and navigation links

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -4,9 +4,10 @@ import HomePage from './page';
 import { describe, it, expect } from 'vitest';
 
 describe('HomePage', () => {
-  it('renders welcome header and reservation button', () => {
+  it('renders welcome header and reservation link', () => {
     const html = renderToString(<HomePage />);
     expect(html).toContain('Welcome to Chandlers');
     expect(html).toContain('Book a reservation');
+    expect(html).toContain('href="/reservations"');
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
+import Link from 'next/link';
 
 export default function HomePage() {
   return (
     <section className="flex items-center justify-center py-24">
       <div className="bg-black/70 p-4 rounded flex flex-col items-center">
         <h1 className="text-6xl font-bold text-white">Welcome to Chandlers</h1>
-        <button
+        <Link
+          href="/reservations"
           className="mt-4 bg-black text-white px-4 py-2 rounded"
           style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
         >
           Book a reservation
-        </button>
+        </Link>
       </div>
     </section>
   );

--- a/src/app/reservations/page.test.tsx
+++ b/src/app/reservations/page.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import ReservationsPage from './page';
+import { describe, it, expect } from 'vitest';
+
+describe('ReservationsPage', () => {
+  it('renders reservations header', () => {
+    const html = renderToString(<ReservationsPage />);
+    expect(html).toContain('Reservations');
+  });
+});

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function ReservationsPage() {
+  return (
+    <section className="flex items-center justify-center py-24">
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+        <h1 className="text-4xl font-bold text-white">Reservations</h1>
+        <p className="mt-2 text-white">Please contact us to book your table.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -21,14 +21,21 @@ export default function Navbar() {
             ☰
           </button>
           {open && (
-            <ul className="absolute right-0 mt-2 w-40 bg-black/80 rounded shadow-lg">
-              <li className="px-4 py-2 hover:bg-black/60">Menu</li>
-              <li className="px-4 py-2 hover:bg-black/60">Reservations</li>
-              <li className="px-4 py-2 hover:bg-black/60">Our Story</li>
-              <li className="px-4 py-2 hover:bg-black/60">Employment</li>
-              <li className="px-4 py-2 hover:bg-black/60">Contacts</li>
-            </ul>
-          )}
+              <ul className="absolute right-0 mt-2 w-40 bg-black/80 rounded shadow-lg">
+                <li className="px-4 py-2 hover:bg-black/60">Menu</li>
+                <li>
+                  <Link
+                    href="/reservations"
+                    className="block px-4 py-2 hover:bg-black/60"
+                  >
+                    Reservations
+                  </Link>
+                </li>
+                <li className="px-4 py-2 hover:bg-black/60">Our Story</li>
+                <li className="px-4 py-2 hover:bg-black/60">Employment</li>
+                <li className="px-4 py-2 hover:bg-black/60">Contacts</li>
+              </ul>
+            )}
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- add dedicated reservations page
- link home page button and navbar item to new reservations page
- cover reservations page and link with tests

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68ab949c68508331b4260147ba74bd85