### PR TITLE
Add menu navigation and reservation link

### DIFF
--- a/src/app/menu/page.test.tsx
+++ b/src/app/menu/page.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import MenuPage from './page';
+import { describe, it, expect } from 'vitest';
+
+describe('MenuPage', () => {
+  it('renders menu header', () => {
+    const html = renderToString(<MenuPage />);
+    expect(html).toContain('Menu');
+  });
+});

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function MenuPage() {
+  return (
+    <section className="flex items-center justify-center py-24">
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+        <h1 className="text-4xl font-bold text-white">Menu</h1>
+        <p className="mt-2 text-white">Our menu is coming soon.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/reservations/page.test.tsx
+++ b/src/app/reservations/page.test.tsx
@@ -8,4 +8,10 @@ describe('ReservationsPage', () => {
     const html = renderToString(<ReservationsPage />);
     expect(html).toContain('Reservations');
   });
+
+  it('includes a link to find a table', () => {
+    const html = renderToString(<ReservationsPage />);
+    expect(html).toContain('Find a table');
+    expect(html).toContain('https://www.opentable.com/chandlers-a-restaurant?');
+  });
 });

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -6,6 +6,13 @@ export default function ReservationsPage() {
       <div className="bg-black/70 p-4 rounded flex flex-col items-center">
         <h1 className="text-4xl font-bold text-white">Reservations</h1>
         <p className="mt-2 text-white">Please contact us to book your table.</p>
+        <a
+          href="https://www.opentable.com/chandlers-a-restaurant?"
+          className="mt-4 bg-black text-white px-4 py-2 rounded"
+          style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
+        >
+          Find a table
+        </a>
       </div>
     </section>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -22,7 +22,11 @@ export default function Navbar() {
           </button>
           {open && (
               <ul className="absolute right-0 mt-2 w-40 bg-black/80 rounded shadow-lg">
-                <li className="px-4 py-2 hover:bg-black/60">Menu</li>
+                <li>
+                  <Link href="/menu" className="block px-4 py-2 hover:bg-black/60">
+                    Menu
+                  </Link>
+                </li>
                 <li>
                   <Link
                     href="/reservations"


### PR DESCRIPTION
## Summary
- Link navbar Menu item to new `/menu` page for navigation
- Add Menu page and basic test
- Add "Find a table" button on reservations page linking to OpenTable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab98baca548331aee44eb0b281e866