### PR TITLE
Add menu buttons for menu categories

### DIFF
--- a/src/app/menu/page.test.tsx
+++ b/src/app/menu/page.test.tsx
@@ -4,8 +4,15 @@ import MenuPage from './page';
 import { describe, it, expect } from 'vitest';
 
 describe('MenuPage', () => {
-  it('renders menu header', () => {
+  it('renders menu header and buttons', () => {
     const html = renderToString(<MenuPage />);
     expect(html).toContain('Menu');
+    const buttonCount = (html.match(/<button/g) || []).length;
+    expect(buttonCount).toBe(5);
+    expect(html).toContain('Drinks');
+    expect(html).toContain('Lunch');
+    expect(html).toContain('Dinner');
+    expect(html).toContain('Dinner Additions');
+    expect(html).toContain('Full Wine List');
   });
 });

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,11 +1,28 @@
 import React from 'react';
 
+const menuItems = [
+  'Drinks',
+  'Lunch',
+  'Dinner',
+  'Dinner Additions',
+  'Full Wine List',
+];
+
 export default function MenuPage() {
   return (
     <section className="flex items-center justify-center py-24">
       <div className="bg-black/70 p-4 rounded flex flex-col items-center">
         <h1 className="text-4xl font-bold text-white">Menu</h1>
-        <p className="mt-2 text-white">Our menu is coming soon.</p>
+        <div className="mt-4 flex flex-col space-y-2 w-full">
+          {menuItems.map((item) => (
+            <button
+              key={item}
+              className="px-4 py-2 bg-white text-black rounded hover:bg-gray-200"
+            >
+              {item}
+            </button>
+          ))}
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- display five menu buttons: Drinks, Lunch, Dinner, Dinner Additions, and Full Wine List
- test for presence of menu buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab9b80b1308331af1503c4dcd3f438