### PR TITLE
Add pages for remaining navbar options

### DIFF
--- a/src/app/contacts/page.test.tsx
+++ b/src/app/contacts/page.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import ContactsPage from './page';
+import { describe, it, expect } from 'vitest';
+
+describe('ContactsPage', () => {
+  it('renders contacts header', () => {
+    const html = renderToString(<ContactsPage />);
+    expect(html).toContain('Contacts');
+  });
+});

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function ContactsPage() {
+  return (
+    <section className="flex items-center justify-center py-24">
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+        <h1 className="text-4xl font-bold text-white">Contacts</h1>
+        <p className="mt-2 text-white">Contact information is coming soon.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/employment/page.test.tsx
+++ b/src/app/employment/page.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import EmploymentPage from './page';
+import { describe, it, expect } from 'vitest';
+
+describe('EmploymentPage', () => {
+  it('renders employment header', () => {
+    const html = renderToString(<EmploymentPage />);
+    expect(html).toContain('Employment');
+  });
+});

--- a/src/app/employment/page.tsx
+++ b/src/app/employment/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function EmploymentPage() {
+  return (
+    <section className="flex items-center justify-center py-24">
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+        <h1 className="text-4xl font-bold text-white">Employment</h1>
+        <p className="mt-2 text-white">Employment opportunities are coming soon.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/our-story/page.test.tsx
+++ b/src/app/our-story/page.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import OurStoryPage from './page';
+import { describe, it, expect } from 'vitest';
+
+describe('OurStoryPage', () => {
+  it('renders our story header', () => {
+    const html = renderToString(<OurStoryPage />);
+    expect(html).toContain('Our Story');
+  });
+});

--- a/src/app/our-story/page.tsx
+++ b/src/app/our-story/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function OurStoryPage() {
+  return (
+    <section className="flex items-center justify-center py-24">
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+        <h1 className="text-4xl font-bold text-white">Our Story</h1>
+        <p className="mt-2 text-white">Our story is coming soon.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -35,9 +35,21 @@ export default function Navbar() {
                     Reservations
                   </Link>
                 </li>
-                <li className="px-4 py-2 hover:bg-black/60">Our Story</li>
-                <li className="px-4 py-2 hover:bg-black/60">Employment</li>
-                <li className="px-4 py-2 hover:bg-black/60">Contacts</li>
+                <li>
+                  <Link href="/our-story" className="block px-4 py-2 hover:bg-black/60">
+                    Our Story
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/employment" className="block px-4 py-2 hover:bg-black/60">
+                    Employment
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/contacts" className="block px-4 py-2 hover:bg-black/60">
+                    Contacts
+                  </Link>
+                </li>
               </ul>
             )}
         </div>


### PR DESCRIPTION
## Summary
- Add Our Story, Employment, and Contacts pages with placeholder copy
- Link navbar dropdown options to their respective pages
- Provide basic tests for each new page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab9cc212588331be832c747bcc51c9