### PR TITLE
Add PDF menus for lunch, dinner additions, and drinks

### DIFF
--- a/src/app/menu/dinner-additions/page.test.tsx
+++ b/src/app/menu/dinner-additions/page.test.tsx
@@ -4,9 +4,10 @@ import DinnerAdditionsMenuPage from './page';
 import { describe, it, expect } from 'vitest';
 
 describe('DinnerAdditionsMenuPage', () => {
-  it('renders dinner additions menu placeholder', () => {
+  it('renders dinner additions menu PDF', () => {
     const html = renderToString(<DinnerAdditionsMenuPage />);
     expect(html).toContain('Dinner Additions');
-    expect(html).toContain('Menu coming soon');
+    expect(html).toContain('chandlers-dinner-add.pdf');
+    expect(html).toContain('<iframe');
   });
 });

--- a/src/app/menu/dinner-additions/page.tsx
+++ b/src/app/menu/dinner-additions/page.tsx
@@ -3,9 +3,12 @@ import React from 'react';
 export default function DinnerAdditionsMenuPage() {
   return (
     <section className="flex items-center justify-center py-24">
-      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center w-full">
         <h1 className="text-4xl font-bold text-white">Dinner Additions</h1>
-        <p className="mt-2 text-white">Menu coming soon.</p>
+        <iframe
+          src="/chandlers-dinner-add.pdf"
+          className="mt-4 w-full h-[80vh]"
+        />
       </div>
     </section>
   );

--- a/src/app/menu/drinks/page.test.tsx
+++ b/src/app/menu/drinks/page.test.tsx
@@ -4,9 +4,10 @@ import DrinksMenuPage from './page';
 import { describe, it, expect } from 'vitest';
 
 describe('DrinksMenuPage', () => {
-  it('renders drinks menu placeholder', () => {
+  it('renders drinks menu PDF', () => {
     const html = renderToString(<DrinksMenuPage />);
     expect(html).toContain('Drinks Menu');
-    expect(html).toContain('Menu coming soon');
+    expect(html).toContain('chandlers-drinks.pdf');
+    expect(html).toContain('<iframe');
   });
 });

--- a/src/app/menu/drinks/page.tsx
+++ b/src/app/menu/drinks/page.tsx
@@ -3,9 +3,12 @@ import React from 'react';
 export default function DrinksMenuPage() {
   return (
     <section className="flex items-center justify-center py-24">
-      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center w-full">
         <h1 className="text-4xl font-bold text-white">Drinks Menu</h1>
-        <p className="mt-2 text-white">Menu coming soon.</p>
+        <iframe
+          src="/chandlers-drinks.pdf"
+          className="mt-4 w-full h-[80vh]"
+        />
       </div>
     </section>
   );

--- a/src/app/menu/lunch/page.test.tsx
+++ b/src/app/menu/lunch/page.test.tsx
@@ -4,9 +4,10 @@ import LunchMenuPage from './page';
 import { describe, it, expect } from 'vitest';
 
 describe('LunchMenuPage', () => {
-  it('renders lunch menu placeholder', () => {
+  it('renders lunch menu PDF', () => {
     const html = renderToString(<LunchMenuPage />);
     expect(html).toContain('Lunch Menu');
-    expect(html).toContain('Menu coming soon');
+    expect(html).toContain('chandlers-lunch.pdf');
+    expect(html).toContain('<iframe');
   });
 });

--- a/src/app/menu/lunch/page.tsx
+++ b/src/app/menu/lunch/page.tsx
@@ -3,9 +3,12 @@ import React from 'react';
 export default function LunchMenuPage() {
   return (
     <section className="flex items-center justify-center py-24">
-      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center w-full">
         <h1 className="text-4xl font-bold text-white">Lunch Menu</h1>
-        <p className="mt-2 text-white">Menu coming soon.</p>
+        <iframe
+          src="/chandlers-lunch.pdf"
+          className="mt-4 w-full h-[80vh]"
+        />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- embed lunch, dinner additions, and drinks PDFs on their respective menu pages
- adjust unit tests to check for the new PDFs and iframe embeds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb4ec180083319db14d856602bc66