### PR TITLE
feat(menu): display Bloody Mary image on menu page

### DIFF
--- a/src/app/menu/page.test.tsx
+++ b/src/app/menu/page.test.tsx
@@ -19,5 +19,6 @@ describe('MenuPage', () => {
     expect(html).toContain('Dinner Additions');
     expect(html).toContain('href="/menu/full-wine-list"');
     expect(html).toContain('Full Wine List');
+    expect(html).toContain('Chandler&#x27;s Bloody Mary');
   });
 });

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 
 const menuItems = [
   { name: 'Drinks', href: '/menu/drinks' },
@@ -12,19 +13,28 @@ const menuItems = [
 export default function MenuPage() {
   return (
     <section className="flex items-center justify-center py-24">
-      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
-        <h1 className="text-4xl font-bold text-white">Menu</h1>
-        <div className="mt-4 flex flex-col space-y-2 w-full">
-          {menuItems.map((item) => (
-            <Link
-              key={item.name}
-              href={item.href}
-              className="px-4 py-2 bg-white text-black rounded hover:bg-gray-200 text-center"
-            >
-              {item.name}
-            </Link>
-          ))}
+      <div className="bg-black/70 p-4 rounded flex items-center space-x-4">
+        <div className="flex flex-col items-center">
+          <h1 className="text-4xl font-bold text-white">Menu</h1>
+          <div className="mt-4 flex flex-col space-y-2 w-full">
+            {menuItems.map((item) => (
+              <Link
+                key={item.name}
+                href={item.href}
+                className="px-4 py-2 bg-white text-black rounded hover:bg-gray-200 text-center"
+              >
+                {item.name}
+              </Link>
+            ))}
+          </div>
         </div>
+        <Image
+          src="/chandlers-bloody.webp"
+          alt="Chandler's Bloody Mary"
+          width={300}
+          height={400}
+          className="rounded"
+        />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add Chandler's Bloody Mary image beside menu options
- test for image rendering on menu page

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68abb7cb2920833181e3e5554d28da21