### PR TITLE
Add detailed footer with navigation and contact info

### DIFF
--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -10,4 +10,10 @@ describe('Footer', () => {
     expect(html).toContain(year);
     expect(html).toContain('Chandlers');
   });
+
+  it('includes navigation links', () => {
+    const html = renderToString(<Footer />);
+    expect(html).toContain('Menu');
+    expect(html).toContain('Reservations');
+  });
 });

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,9 +1,51 @@
 import React from 'react';
+import Link from 'next/link';
 
 export default function Footer() {
+  const year = new Date().getFullYear();
+
   return (
-    <footer className="bg-gray-800 text-white text-center py-4">
-      <p>&copy; {new Date().getFullYear()} Chandlers. All rights reserved.</p>
+    <footer className="bg-black/70 text-white mt-8">
+      <div className="max-w-7xl mx-auto px-4 py-10 grid gap-8 text-center md:text-left md:grid-cols-3">
+        <div>
+          <h2 className="text-2xl font-semibold">Chandlers</h2>
+          <p className="mt-2">215 Howard St, Petoskey, MI</p>
+          <p>(231) 347-0254</p>
+        </div>
+        <div>
+          <h3 className="text-xl font-semibold mb-2">Navigate</h3>
+          <ul className="space-y-1">
+            <li>
+              <Link href="/menu" className="hover:underline">
+                Menu
+              </Link>
+            </li>
+            <li>
+              <Link href="/reservations" className="hover:underline">
+                Reservations
+              </Link>
+            </li>
+            <li>
+              <Link href="/our-story" className="hover:underline">
+                Our Story
+              </Link>
+            </li>
+            <li>
+              <Link href="/employment" className="hover:underline">
+                Employment
+              </Link>
+            </li>
+            <li>
+              <Link href="/contacts" className="hover:underline">
+                Contact
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div className="md:text-right flex flex-col justify-between">
+          <p>&copy; {year} Chandlers. All rights reserved.</p>
+        </div>
+      </div>
     </footer>
   );
 }


### PR DESCRIPTION
## Summary
- expand footer with restaurant address, phone number, and quick navigation links
- cover footer with tests for current year and nav links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb8d5cb58833186b65d20ae686d59