### PR TITLE
feat: add private events page and navbar link

### DIFF
--- a/src/app/private-events/page.test.tsx
+++ b/src/app/private-events/page.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import PrivateEventsPage from './page';
+import { describe, it, expect } from 'vitest';
+
+describe('PrivateEventsPage', () => {
+  it('renders private events header', () => {
+    const html = renderToString(<PrivateEventsPage />);
+    expect(html).toContain('Private Events');
+  });
+});

--- a/src/app/private-events/page.tsx
+++ b/src/app/private-events/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function PrivateEventsPage() {
+  return (
+    <section className="flex items-center justify-center py-24">
+      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+        <h1 className="text-4xl font-bold text-white">Private Events</h1>
+        <p className="mt-2 text-white">Information about private events is coming soon.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -36,6 +36,11 @@ export default function Navbar() {
                   </Link>
                 </li>
                 <li>
+                  <Link href="/private-events" className="block px-4 py-2 hover:bg-black/60">
+                    Private Events
+                  </Link>
+                </li>
+                <li>
                   <Link href="/our-story" className="block px-4 py-2 hover:bg-black/60">
                     Our Story
                   </Link>


### PR DESCRIPTION
## Summary
- add Private Events link to hamburger menu
- create Private Events page
- test rendering of Private Events page

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68abb9c4ee30833196a4f473bc21333b