### PR TITLE
Make home page scrollable with parallax background

### DIFF
--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function ContactsPage() {
   return (
-    <section className="flex items-center justify-center py-24">
+    <section id="contacts" className="flex items-center justify-center py-24">
       <div className="bg-black/70 p-4 rounded flex flex-col items-center">
         <h1 className="text-4xl font-bold text-white">Contacts</h1>
         <p className="mt-2 text-white">Contact information is coming soon.</p>

--- a/src/app/employment/page.tsx
+++ b/src/app/employment/page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function EmploymentPage() {
   return (
-    <section className="flex items-center justify-center py-24">
+    <section id="employment" className="flex items-center justify-center py-24">
       <div className="bg-black/70 p-4 rounded flex flex-col items-center">
         <h1 className="text-4xl font-bold text-white">Employment</h1>
         <p className="mt-2 text-white">Employment opportunities are coming soon.</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,7 +14,6 @@ body {
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  background-attachment: fixed;
   color: #1f2937;
   line-height: 1.5;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import ParallaxBackground from "@/components/ParallaxBackground";
 
 export const metadata = {
   title: {
@@ -18,6 +19,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="min-h-screen flex flex-col">
+        <ParallaxBackground />
         <Navbar />
         <main className="flex-1">
           {children}

--- a/src/app/our-story/page.tsx
+++ b/src/app/our-story/page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function OurStoryPage() {
   return (
-    <section className="flex items-center justify-center py-24">
+    <section id="our-story" className="flex items-center justify-center py-24">
       <div className="bg-black/70 p-4 rounded flex flex-col items-center">
         <h1 className="text-4xl font-bold text-white">Our Story</h1>
         <p className="mt-2 text-white">Our story is coming soon.</p>

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -22,9 +22,9 @@ describe('HomePage', () => {
     // The visible CTA text should be present
     expect(html).toContain('Book a reservation');
 
-    // Pass if it's a link to /reservations ...
+    // Pass if it's a link to the reservations section on the home page ...
     const hasReservationLink =
-      /<a[^>]*href=(["'])\/reservations\1[^>]*>[\s\S]*?Book a reservation[\s\S]*?<\/a>/i.test(
+      /<a[^>]*href=(["'])\/?#reservations\1[^>]*>[\s\S]*?Book a reservation[\s\S]*?<\/a>/i.test(
         html
       );
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,34 @@
 // page.tsx (or page.jsx)
 import React from 'react';
 import Link from 'next/link';
+import ReservationsPage from './reservations/page';
+import PrivateEventsPage from './private-events/page';
+import OurStoryPage from './our-story/page';
+import EmploymentPage from './employment/page';
+import ContactsPage from './contacts/page';
 
 export default function HomePage() {
   return (
-    <section className="flex min-h-screen items-center justify-center py-24">
-      <div className="bg-black/70 p-6 rounded-xl flex flex-col items-center">
-        <h1 className="text-6xl font-bold text-white">Welcome to Chandlers</h1>
+    <>
+      <section className="flex min-h-screen items-center justify-center py-24">
+        <div className="bg-black/70 p-6 rounded-xl flex flex-col items-center">
+          <h1 className="text-6xl font-bold text-white">Welcome to Chandlers</h1>
 
-        <Link
-          href="/reservations"
-          className="mt-4 bg-black text-white px-4 py-2 rounded"
-          style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
-          aria-label="Book a reservation"
-        >
-          Book a reservation
-        </Link>
-      </div>
-    </section>
+          <Link
+            href="#reservations"
+            className="mt-4 bg-black text-white px-4 py-2 rounded"
+            style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
+            aria-label="Book a reservation"
+          >
+            Book a reservation
+          </Link>
+        </div>
+      </section>
+      <ReservationsPage />
+      <PrivateEventsPage />
+      <OurStoryPage />
+      <EmploymentPage />
+      <ContactsPage />
+    </>
   );
 }

--- a/src/app/private-events/page.tsx
+++ b/src/app/private-events/page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function PrivateEventsPage() {
   return (
-    <section className="flex items-center justify-center py-24">
+    <section id="private-events" className="flex items-center justify-center py-24">
       <div className="bg-black/70 p-4 rounded flex flex-col items-center">
         <h1 className="text-4xl font-bold text-white">Private Events</h1>
         <p className="mt-2 text-white">Information about private events is coming soon.</p>

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function ReservationsPage() {
   return (
-    <section className="flex items-center justify-center py-24">
+    <section id="reservations" className="flex items-center justify-center py-24">
       <div className="bg-black/70 p-4 rounded flex flex-col items-center">
         <h1 className="text-4xl font-bold text-white">Reservations</h1>
         <p className="mt-2 text-white">Please contact us to book your table.</p>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,29 +29,29 @@ export default function Navbar() {
                 </li>
                 <li>
                   <Link
-                    href="/reservations"
+                    href="/#reservations"
                     className="block px-4 py-2 hover:bg-black/60"
                   >
                     Reservations
                   </Link>
                 </li>
                 <li>
-                  <Link href="/private-events" className="block px-4 py-2 hover:bg-black/60">
+                  <Link href="/#private-events" className="block px-4 py-2 hover:bg-black/60">
                     Private Events
                   </Link>
                 </li>
                 <li>
-                  <Link href="/our-story" className="block px-4 py-2 hover:bg-black/60">
+                  <Link href="/#our-story" className="block px-4 py-2 hover:bg-black/60">
                     Our Story
                   </Link>
                 </li>
                 <li>
-                  <Link href="/employment" className="block px-4 py-2 hover:bg-black/60">
+                  <Link href="/#employment" className="block px-4 py-2 hover:bg-black/60">
                     Employment
                   </Link>
                 </li>
                 <li>
-                  <Link href="/contacts" className="block px-4 py-2 hover:bg-black/60">
+                  <Link href="/#contacts" className="block px-4 py-2 hover:bg-black/60">
                     Contacts
                   </Link>
                 </li>

--- a/src/components/ParallaxBackground.tsx
+++ b/src/components/ParallaxBackground.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from 'react';
+
+export default function ParallaxBackground() {
+  useEffect(() => {
+    const handleScroll = () => {
+      const offset = window.scrollY * 0.25;
+      document.body.style.backgroundPosition = `center ${-offset}px`;
+    };
+    window.addEventListener('scroll', handleScroll);
+    handleScroll();
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Embed reservations, private events, story, employment, and contact sections directly on the home page
- Update navigation and hero button to anchor to the new sections
- Implement a parallax background that scrolls at one quarter speed

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68abc09002188331a0d9a5ce985fb78f