### PR TITLE
Show home page background at native resolution

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,7 +11,7 @@ body {
   background-color: #f8f8f8; /* fallback color */
   /* Use a local restaurant-themed image for the home page background */
   background-image: url('/images/chandlers-barton-art-1.jpg');
-  background-size: cover;
+  background-size: auto;
   background-position: center;
   background-repeat: no-repeat;
   color: #1f2937;


### PR DESCRIPTION
## Summary
- Display home page background at its native size to avoid distortion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abc31b50a483318e8cd49c5568c8f7