### PR TITLE
feat: integrate menu into home page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,11 +9,12 @@ html {
 body {
   font-family: system-ui, sans-serif;
   background-color: #f8f8f8; /* fallback color */
-  /* Use a local restaurant-themed image for the home page background */
-  background-image: url('/images/chandlers-barton-art-1.jpg');
-  background-size: auto;
-  background-position: center;
-  background-repeat: no-repeat;
+  /* Use local restaurant-themed images for a scrolling collage */
+  background-image: url('/images/chandlers-barton-art-1.jpg'),
+    url('/chandlers-bloody.webp');
+  background-size: auto, 400px;
+  background-position: center top, right 0 top 700px;
+  background-repeat: no-repeat, no-repeat;
   color: #1f2937;
   line-height: 1.5;
 }

--- a/src/app/menu/page.test.tsx
+++ b/src/app/menu/page.test.tsx
@@ -19,6 +19,5 @@ describe('MenuPage', () => {
     expect(html).toContain('Dinner Additions');
     expect(html).toContain('href="/menu/full-wine-list"');
     expect(html).toContain('Full Wine List');
-    expect(html).toContain('Chandler&#x27;s Bloody Mary');
   });
 });

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 
 const menuItems = [
   { name: 'Drinks', href: '/menu/drinks' },
@@ -13,7 +12,7 @@ const menuItems = [
 export default function MenuPage() {
   return (
     <section className="flex items-center justify-center py-24">
-      <div className="bg-black/70 p-4 rounded flex items-center space-x-4">
+      <div className="bg-black/70 p-4 rounded">
         <div className="flex flex-col items-center">
           <h1 className="text-4xl font-bold text-white">Menu</h1>
           <div className="mt-4 flex flex-col space-y-2 w-full">
@@ -28,13 +27,6 @@ export default function MenuPage() {
             ))}
           </div>
         </div>
-        <Image
-          src="/chandlers-bloody.webp"
-          alt="Chandler's Bloody Mary"
-          width={300}
-          height={400}
-          className="rounded"
-        />
       </div>
     </section>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import Link from 'next/link';
 import ReservationsPage from './reservations/page';
+import MenuPage from './menu/page';
 import PrivateEventsPage from './private-events/page';
 import OurStoryPage from './our-story/page';
 import EmploymentPage from './employment/page';
@@ -25,6 +26,7 @@ export default function HomePage() {
         </div>
       </section>
       <ReservationsPage />
+      <MenuPage />
       <PrivateEventsPage />
       <OurStoryPage />
       <EmploymentPage />


### PR DESCRIPTION
## Summary
- include menu section directly on the home page
- drop standalone Bloody Mary image from menu and reposition it in the page background collage

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68abc7011b008331a6195ade1bab0ba3