### PR TITLE
Fix homepage background image layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,9 +4,9 @@
 
 /* Tweak these to fit your design */
 :root {
-  --hero-h: clamp(360px, 55vh, 640px); /* visual height of the top hero */
-  --gap: 24px;                         /* space between hero and the two tiles */
-  --tile-h: 400px;                     /* height of each bottom tile */
+  --hero-h: 100vh; /* visual height of the top hero */
+  --gap: 24px;     /* space between hero and the two tiles */
+  --tile-h: 400px; /* height of each bottom tile */
 }
 
 html { scroll-behavior: smooth; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import ContactsPage from './contacts/page';
 export default function HomePage() {
   return (
     <>
-      <section className="flex min-h-screen items-center justify-center py-24">
+      <section className="flex min-h-screen items-center justify-center">
         <div className="bg-black/70 p-6 rounded-xl flex flex-col items-center">
           <h1 className="text-6xl font-bold text-white">Welcome to Chandlers</h1>
 


### PR DESCRIPTION
## Summary
- Align hero background height with layout variables
- Remove extra padding to display lower background images

## Testing
- `npm test`
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68abce7bd8d88331b336ac07cf1d0136