### PR TITLE
Display hero and reservation images

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,29 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Tweak these to fit your design */
-:root {
-  --hero-h: 100vh; /* visual height of the top hero */
-  --gap: 24px;     /* space between hero and the two tiles */
-  --tile-h: 400px; /* height of each bottom tile */
-}
-
 html { scroll-behavior: smooth; }
 
 body {
   font-family: system-ui, sans-serif;
-
-  /* Layered backgrounds:
-     1) Right tile (on top), 2) Left tile, 3) Hero (behind), then a fallback color */
-  background:
-    url('/images/chandlers-wine-crates.jpg') right 0 top calc(var(--hero-h) + var(--gap)) / 50% var(--tile-h) no-repeat,
-    url('/images/chandlers-bloody.jpg')      left  0 top calc(var(--hero-h) + var(--gap)) / 50% var(--tile-h) no-repeat,
-    url('/images/chandlers-barton-art-1.jpg') center top / cover no-repeat
-    #f8f8f8;
-
-  /* Ensure there’s enough page height to actually reveal the lower row */
-  min-height: calc(var(--hero-h) + var(--gap) + var(--tile-h) + 1px);
-
+  background-color: #f8f8f8;
   color: #1f2937;
   line-height: 1.5;
 }
@@ -37,4 +19,4 @@ h1, .site-title {
 }
 h2, h3, h4, h5, h6 { font-family: Georgia, serif; font-weight: 600; }
 a { @apply text-primary underline-offset-4 hover:underline; }
-img { max-width: 100%; height: auto; display: block; }
+img { display: block; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,18 +11,24 @@ import ContactsPage from './contacts/page';
 export default function HomePage() {
   return (
     <>
-      <section className="flex min-h-screen items-center justify-center">
-        <div className="bg-black/70 p-6 rounded-xl flex flex-col items-center">
-          <h1 className="text-6xl font-bold text-white">Welcome to Chandlers</h1>
+      <section className="relative w-fit mx-auto">
+        <img
+          src="/images/chandlers-barton-art-1.jpg"
+          alt="Chandlers artwork"
+        />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="bg-black/70 p-6 rounded-xl flex flex-col items-center">
+            <h1 className="text-6xl font-bold text-white">Welcome to Chandlers</h1>
 
-          <Link
-            href="#reservations"
-            className="mt-4 bg-black text-white px-4 py-2 rounded"
-            style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
-            aria-label="Book a reservation"
-          >
-            Book a reservation
-          </Link>
+            <Link
+              href="#reservations"
+              className="mt-4 bg-black text-white px-4 py-2 rounded"
+              style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
+              aria-label="Book a reservation"
+            >
+              Book a reservation
+            </Link>
+          </div>
         </div>
       </section>
       <ReservationsPage />

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -2,8 +2,15 @@ import React from 'react';
 
 export default function ReservationsPage() {
   return (
-    <section id="reservations" className="flex items-center justify-center py-24">
-      <div className="bg-black/70 p-4 rounded flex flex-col items-center">
+    <section
+      id="reservations"
+      className="relative flex items-center justify-center py-24 min-h-[400px] overflow-hidden"
+    >
+      <div className="absolute inset-0 flex justify-between items-center">
+        <img src="/images/chandlers-bloody.jpg" alt="" className="flex-none" />
+        <img src="/images/chandlers-wine-crates.jpg" alt="" className="flex-none" />
+      </div>
+      <div className="relative z-10 bg-black/70 p-4 rounded flex flex-col items-center">
         <h1 className="text-4xl font-bold text-white">Reservations</h1>
         <p className="mt-2 text-white">Please contact us to book your table.</p>
         <a


### PR DESCRIPTION
## Summary
- Render chandlers-barton-art hero image at intrinsic size without stretching
- Show chandlers-bloody and chandlers-wine-crates side by side behind reservations without scaling
- Remove global image max-width rule to preserve native dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7f9d67d083319d6ec200018fd34c