### PR TITLE
Enable smooth scrolling for home page navigation links

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,14 @@ import EmploymentPage from './employment/page';
 import ContactsPage from './contacts/page';
 
 export default function HomePage() {
+  const handleScroll = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    targetId: string
+  ) => {
+    e.preventDefault();
+    document.getElementById(targetId)?.scrollIntoView({ behavior: 'smooth' });
+  };
+
   return (
     <>
       <section className="flex min-h-screen items-center justify-center">
@@ -20,6 +28,7 @@ export default function HomePage() {
             className="mt-4 bg-black text-white px-4 py-2 rounded"
             style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
             aria-label="Book a reservation"
+            onClick={(e) => handleScroll(e, 'reservations')}
           >
             Book a reservation
           </Link>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,6 +6,19 @@ import Link from 'next/link';
 export default function Navbar() {
   const [open, setOpen] = useState(false);
 
+  const handleScroll = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    targetId: string
+  ) => {
+    if (window.location.pathname === '/') {
+      e.preventDefault();
+      document.getElementById(targetId)?.scrollIntoView({
+        behavior: 'smooth',
+      });
+      setOpen(false);
+    }
+  };
+
   return (
     <nav className="bg-black/70 text-white">
       <div className="mx-auto max-w-7xl px-4 py-6 flex justify-between items-center">
@@ -23,7 +36,11 @@ export default function Navbar() {
           {open && (
               <ul className="absolute right-0 mt-2 w-40 bg-black/80 rounded shadow-lg">
                 <li>
-                  <Link href="/menu" className="block px-4 py-2 hover:bg-black/60">
+                  <Link
+                    href="/menu"
+                    className="block px-4 py-2 hover:bg-black/60"
+                    onClick={() => setOpen(false)}
+                  >
                     Menu
                   </Link>
                 </li>
@@ -31,27 +48,44 @@ export default function Navbar() {
                   <Link
                     href="/#reservations"
                     className="block px-4 py-2 hover:bg-black/60"
+                    onClick={(e) => handleScroll(e, 'reservations')}
                   >
                     Reservations
                   </Link>
                 </li>
                 <li>
-                  <Link href="/#private-events" className="block px-4 py-2 hover:bg-black/60">
+                  <Link
+                    href="/#private-events"
+                    className="block px-4 py-2 hover:bg-black/60"
+                    onClick={(e) => handleScroll(e, 'private-events')}
+                  >
                     Private Events
                   </Link>
                 </li>
                 <li>
-                  <Link href="/#our-story" className="block px-4 py-2 hover:bg-black/60">
+                  <Link
+                    href="/#our-story"
+                    className="block px-4 py-2 hover:bg-black/60"
+                    onClick={(e) => handleScroll(e, 'our-story')}
+                  >
                     Our Story
                   </Link>
                 </li>
                 <li>
-                  <Link href="/#employment" className="block px-4 py-2 hover:bg-black/60">
+                  <Link
+                    href="/#employment"
+                    className="block px-4 py-2 hover:bg-black/60"
+                    onClick={(e) => handleScroll(e, 'employment')}
+                  >
                     Employment
                   </Link>
                 </li>
                 <li>
-                  <Link href="/#contacts" className="block px-4 py-2 hover:bg-black/60">
+                  <Link
+                    href="/#contacts"
+                    className="block px-4 py-2 hover:bg-black/60"
+                    onClick={(e) => handleScroll(e, 'contacts')}
+                  >
                     Contacts
                   </Link>
                 </li>


### PR DESCRIPTION
## Summary
- Add smooth scrolling handler for navbar links to home page sections
- Smoothly scroll to reservations section from hero CTA

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8c8af4f8833199456664eab434be