### PR TITLE
Fix closing tags on home page banner

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,16 +27,16 @@ export default function HomePage() {
         <div className="absolute inset-0 flex items-center justify-center">
           <div className="bg-black/70 p-6 rounded-xl flex flex-col items-center">
             <h1 className="text-6xl font-bold text-white">Welcome to Chandlers</h1>
-
-<Link
-  href="#reservations"
-  className="mt-4 bg-black text-white px-4 py-2 rounded"
-  style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
-  aria-label="Book a reservation"
-  onClick={(e) => handleScroll(e, 'reservations')}
->
-  Book a reservation
-</Link>
+            <Link
+              href="#reservations"
+              className="mt-4 bg-black text-white px-4 py-2 rounded"
+              style={{ fontFamily: 'Copperplate', fontWeight: 'bold' }}
+              aria-label="Book a reservation"
+              onClick={(e) => handleScroll(e, 'reservations')}
+            >
+              Book a reservation
+            </Link>
+          </div>
         </div>
       </section>
       <ReservationsPage />


### PR DESCRIPTION
## Summary
- Fix home page banner structure by closing missing `div` wrapper

## Testing
- `npm test`
- `npm run lint` *(fails: asks 'How would you like to configure ESLint?')*

------
https://chatgpt.com/codex/tasks/task_e_68ac916c2294833192ff3615085aa17d